### PR TITLE
feat: Multi-org GitHub App support

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/github/github-mcp-server/internal/ghmcp"
 	"github.com/github/github-mcp-server/pkg/github"
@@ -45,6 +47,9 @@ var (
 				return fmt.Errorf("failed to unmarshal toolsets: %w", err)
 			}
 
+			// Parse multi-org installations
+			installations := parseOrgInstallations()
+
 			stdioServerConfig := ghmcp.StdioServerConfig{
 				Version:              version,
 				Host:                 viper.GetString("host"),
@@ -55,12 +60,41 @@ var (
 				ExportTranslations:   viper.GetBool("export-translations"),
 				EnableCommandLogging: viper.GetBool("enable-command-logging"),
 				LogFilePath:          viper.GetString("log-file"),
+				Installations:        installations,
 			}
 
 			return ghmcp.RunStdioServer(stdioServerConfig)
 		},
 	}
 )
+
+// parseOrgInstallations parses GITHUB_INSTALLATION_ID_<ORG> environment variables
+// and returns a map of organization name to installation ID.
+// Also includes the default GITHUB_INSTALLATION_ID under "_default" key if set.
+func parseOrgInstallations() map[string]int64 {
+	installations := make(map[string]int64)
+	prefix := "GITHUB_INSTALLATION_ID_"
+
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, prefix) {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				org := strings.ToLower(strings.TrimPrefix(parts[0], prefix))
+				org = strings.ReplaceAll(org, "_", "-") // Normalize underscores to dashes
+				if id, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
+					installations[org] = id
+				}
+			}
+		}
+	}
+
+	// Add default if set (for backwards compatibility)
+	if defaultID := viper.GetInt64("installation_id"); defaultID != 0 {
+		installations["_default"] = defaultID
+	}
+
+	return installations
+}
 
 func init() {
 	cobra.OnInitialize(initConfig)

--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/github/github-mcp-server/pkg/github"
@@ -201,6 +200,9 @@ type MCPServerConfig struct {
 	// ReadOnly indicates if we should only offer read-only tools
 	ReadOnly bool
 
+	// Installations maps organization names to GitHub App installation IDs
+	Installations map[string]int64
+
 	// Translator provides translated text for the server tooling
 	Translator translations.TranslationHelperFunc
 }
@@ -212,8 +214,8 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 		return nil, fmt.Errorf("failed to create GitHub REST client: %w", err)
 	}
 
-	// Create GraphQL client
-	gqlClient, gqlHTTPClient, err := createGQLClient(cfg)
+	// Create GraphQL client (for user agent hook only; actual GQL clients from factory)
+	_, gqlHTTPClient, err := createGQLClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GitHub GraphQL client: %w", err)
 	}
@@ -252,13 +254,19 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 		}
 	}
 
-	// Create repository-aware client factory with 1-hour cache TTL
-	clientFactory := github.NewRepoAwareClientFactory(restClient, 1*time.Hour)
-	getClient := clientFactory.GetClientFn()
+	// Create multi-org client factory
+	appID := viper.GetInt64("app_id")
+	privateKey := []byte(viper.GetString("private_key"))
 
-	getGQLClient := func(_ context.Context) (*githubv4.Client, error) {
-		return gqlClient, nil // closing over client
-	}
+	clientFactory := github.NewMultiOrgClientFactory(
+		appID,
+		privateKey,
+		cfg.Installations,
+		cfg.Host,
+		cfg.Version,
+	)
+	getClient := clientFactory.GetClientFn()
+	getGQLClient := clientFactory.GetGQLClientFn()
 
 	// Create default toolsets
 	toolsets, err := github.InitToolsets(
@@ -315,6 +323,9 @@ type StdioServerConfig struct {
 
 	// Path to the log file if not stderr
 	LogFilePath string
+
+	// Installations maps organization names to GitHub App installation IDs
+	Installations map[string]int64
 }
 
 // RunStdioServer is not concurrent safe.
@@ -332,6 +343,7 @@ func RunStdioServer(cfg StdioServerConfig) error {
 		EnabledToolsets: cfg.EnabledToolsets,
 		DynamicToolsets: cfg.DynamicToolsets,
 		ReadOnly:        cfg.ReadOnly,
+		Installations:   cfg.Installations,
 		Translator:      t,
 	})
 	if err != nil {

--- a/pkg/github/code_scanning.go
+++ b/pkg/github/code_scanning.go
@@ -47,7 +47,7 @@ func GetCodeScanningAlert(getClient GetClientFn, t translations.TranslationHelpe
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -132,7 +132,7 @@ func ListCodeScanningAlerts(getClient GetClientFn, t translations.TranslationHel
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}

--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -25,7 +25,7 @@ func GetMe(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mc
 			),
 		),
 		func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -49,7 +49,7 @@ func GetIssue(getClient GetClientFn, t translations.TranslationHelperFunc) (tool
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -123,7 +123,7 @@ func AddIssueComment(getClient GetClientFn, t translations.TranslationHelperFunc
 				Body: github.Ptr(body),
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -211,7 +211,7 @@ func SearchIssues(getClient GetClientFn, t translations.TranslationHelperFunc) (
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -333,7 +333,7 @@ func CreateIssue(getClient GetClientFn, t translations.TranslationHelperFunc) (t
 				Milestone: milestoneNum,
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -455,7 +455,7 @@ func ListIssues(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 				opts.PerPage = int(perPage)
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -601,7 +601,7 @@ func UpdateIssue(getClient GetClientFn, t translations.TranslationHelperFunc) (t
 				issueRequest.Milestone = &milestoneNum
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -684,7 +684,7 @@ func GetIssueComments(getClient GetClientFn, t translations.TranslationHelperFun
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -50,7 +50,7 @@ func GetPullRequest(getClient GetClientFn, t translations.TranslationHelperFunc)
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -165,7 +165,7 @@ func CreatePullRequest(getClient GetClientFn, t translations.TranslationHelperFu
 			newPR.Draft = github.Ptr(draft)
 			newPR.MaintainerCanModify = github.Ptr(maintainerCanModify)
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -286,7 +286,7 @@ func UpdatePullRequest(getClient GetClientFn, t translations.TranslationHelperFu
 				return mcp.NewToolResultError("No update parameters provided."), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -395,7 +395,7 @@ func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFun
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -484,7 +484,7 @@ func MergePullRequest(getClient GetClientFn, t translations.TranslationHelperFun
 				MergeMethod: mergeMethod,
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -546,7 +546,7 @@ func GetPullRequestFiles(getClient GetClientFn, t translations.TranslationHelper
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -609,7 +609,7 @@ func GetPullRequestStatus(getClient GetClientFn, t translations.TranslationHelpe
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			// First get the PR to find the head SHA
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -697,7 +697,7 @@ func UpdatePullRequestBranch(getClient GetClientFn, t translations.TranslationHe
 				opts.ExpectedHeadSHA = github.Ptr(expectedHeadSHA)
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -770,7 +770,7 @@ func GetPullRequestComments(getClient GetClientFn, t translations.TranslationHel
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -832,7 +832,7 @@ func GetPullRequestReviews(getClient GetClientFn, t translations.TranslationHelp
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -908,7 +908,7 @@ func CreateAndSubmitPullRequestReview(getGQLClient GetGQLClientFn, t translation
 			}
 
 			// Given our owner, repo and PR number, lookup the GQL ID of the PR.
-			client, err := getGQLClient(ctx)
+			client, err := getGQLClient(ctx, params.Owner)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil
 			}
@@ -999,7 +999,7 @@ func CreatePendingPullRequestReview(getGQLClient GetGQLClientFn, t translations.
 			}
 
 			// Given our owner, repo and PR number, lookup the GQL ID of the PR.
-			client, err := getGQLClient(ctx)
+			client, err := getGQLClient(ctx, params.Owner)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil
 			}
@@ -1121,7 +1121,7 @@ func AddPullRequestReviewCommentToPendingReview(getGQLClient GetGQLClientFn, t t
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getGQLClient(ctx)
+			client, err := getGQLClient(ctx, params.Owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub GQL client: %w", err)
 			}
@@ -1252,7 +1252,7 @@ func SubmitPendingPullRequestReview(getGQLClient GetGQLClientFn, t translations.
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getGQLClient(ctx)
+			client, err := getGQLClient(ctx, params.Owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub GQL client: %w", err)
 			}
@@ -1367,7 +1367,7 @@ func DeletePendingPullRequestReview(getGQLClient GetGQLClientFn, t translations.
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getGQLClient(ctx)
+			client, err := getGQLClient(ctx, params.Owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub GQL client: %w", err)
 			}
@@ -1476,7 +1476,7 @@ func GetPullRequestDiff(getClient GetClientFn, t translations.TranslationHelperF
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, params.Owner)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get GitHub client: %v", err)), nil
 			}
@@ -1546,7 +1546,7 @@ func RequestCopilotReview(getClient GetClientFn, t translations.TranslationHelpe
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/github/repo_access.go
+++ b/pkg/github/repo_access.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v69/github"
+	"github.com/shurcooL/githubv4"
 )
 
 // RepoAccessType indicates how a repository should be accessed
@@ -145,17 +148,153 @@ func WithRepoContext(ctx context.Context, owner, repo string) context.Context {
 	return ctx
 }
 
-// GetClientFn returns a function that gets the appropriate client based on context
+// GetClientFn returns a function that gets the appropriate client based on context or owner
 func (f *RepoAwareClientFactory) GetClientFn() GetClientFn {
-	return func(ctx context.Context) (*github.Client, error) {
-		owner, ok1 := ctx.Value("github.owner").(string)
-		repo, ok2 := ctx.Value("github.repo").(string)
+	return func(ctx context.Context, owner string) (*github.Client, error) {
+		// If owner not provided, try to get from context
+		if owner == "" {
+			ownerFromCtx, ok1 := ctx.Value("github.owner").(string)
+			repo, ok2 := ctx.Value("github.repo").(string)
 
-		if !ok1 || !ok2 {
-			// If we can't determine the repo, use authenticated client
-			return f.authClient, nil
+			if !ok1 || !ok2 {
+				// If we can't determine the repo, use authenticated client
+				return f.authClient, nil
+			}
+
+			return f.GetClientForRepo(ctx, ownerFromCtx, repo)
 		}
 
-		return f.GetClientForRepo(ctx, owner, repo)
+		// Use provided owner
+		return f.authClient, nil
 	}
+}
+
+// MultiOrgClientFactory creates GitHub clients for different organizations
+type MultiOrgClientFactory struct {
+	appID          int64
+	privateKey     []byte
+	installations  map[string]int64 // org -> installation_id
+	defaultInstall int64
+	transports     map[string]*ghinstallation.Transport // cached per-org
+	transportsMu   sync.RWMutex
+	host           string
+	version        string
+}
+
+// NewMultiOrgClientFactory creates a new multi-org client factory
+func NewMultiOrgClientFactory(
+	appID int64,
+	privateKey []byte,
+	installations map[string]int64,
+	host, version string,
+) *MultiOrgClientFactory {
+	defaultInstall := installations["_default"]
+	delete(installations, "_default")
+
+	return &MultiOrgClientFactory{
+		appID:          appID,
+		privateKey:     privateKey,
+		installations:  installations,
+		defaultInstall: defaultInstall,
+		transports:     make(map[string]*ghinstallation.Transport),
+		host:           host,
+		version:        version,
+	}
+}
+
+// getInstallationID returns the installation ID for a given organization
+func (f *MultiOrgClientFactory) getInstallationID(owner string) int64 {
+	owner = strings.ToLower(owner)
+
+	// Try exact match first
+	if id, ok := f.installations[owner]; ok {
+		return id
+	}
+
+	// Fall back to default
+	return f.defaultInstall
+}
+
+// GetClientFn returns a function that gets the appropriate client based on owner
+func (f *MultiOrgClientFactory) GetClientFn() GetClientFn {
+	return func(ctx context.Context, owner string) (*github.Client, error) {
+		if owner == "" {
+			// User-scoped operations (GetMe) use default
+			owner = "_default"
+		}
+
+		installID := f.getInstallationID(owner)
+		if installID == 0 {
+			// No installation for this org - return anonymous client
+			// This allows public repo operations to succeed
+			client := github.NewClient(nil)
+			client.UserAgent = fmt.Sprintf("github-mcp-server/%s", f.version)
+			return client, nil
+		}
+
+		// Get or create transport for this installation
+		transport, err := f.getOrCreateTransport(owner, installID)
+		if err != nil {
+			return nil, err
+		}
+
+		client := github.NewClient(&http.Client{Transport: transport})
+		client.UserAgent = fmt.Sprintf("github-mcp-server/%s", f.version)
+		return client, nil
+	}
+}
+
+// GetGQLClientFn returns a function that gets the appropriate GraphQL client based on owner
+func (f *MultiOrgClientFactory) GetGQLClientFn() GetGQLClientFn {
+	return func(ctx context.Context, owner string) (*githubv4.Client, error) {
+		if owner == "" {
+			// User-scoped operations use default
+			owner = "_default"
+		}
+
+		installID := f.getInstallationID(owner)
+		if installID == 0 {
+			// No installation for this org - return anonymous client
+			return githubv4.NewClient(nil), nil
+		}
+
+		// Get or create transport for this installation
+		transport, err := f.getOrCreateTransport(owner, installID)
+		if err != nil {
+			return nil, err
+		}
+
+		client := githubv4.NewClient(&http.Client{Transport: transport})
+		return client, nil
+	}
+}
+
+// getOrCreateTransport gets or creates a cached transport for an organization
+func (f *MultiOrgClientFactory) getOrCreateTransport(org string, installID int64) (*ghinstallation.Transport, error) {
+	f.transportsMu.RLock()
+	if t, ok := f.transports[org]; ok {
+		f.transportsMu.RUnlock()
+		return t, nil
+	}
+	f.transportsMu.RUnlock()
+
+	f.transportsMu.Lock()
+	defer f.transportsMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if t, ok := f.transports[org]; ok {
+		return t, nil
+	}
+
+	transport, err := ghinstallation.New(http.DefaultTransport, f.appID, installID, f.privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transport for %s: %w", org, err)
+	}
+
+	if f.host != "" {
+		transport.BaseURL = f.host
+	}
+
+	f.transports[org] = transport
+	return transport, nil
 }

--- a/pkg/github/repo_access_test.go
+++ b/pkg/github/repo_access_test.go
@@ -152,18 +152,18 @@ func TestRepoAwareClientFactory_GetClientForRepo(t *testing.T) {
 
 	// Test context-based client selection
 	ctx := WithRepoContext(context.Background(), "owner", "private-repo")
-	client, err = factory.GetClientFn()(ctx)
+	client, err = factory.GetClientFn()(ctx, "")
 	assert.NoError(t, err)
 	assert.Equal(t, authClient, client)
 
 	ctx = WithRepoContext(context.Background(), "owner", "public-repo")
-	client, err = factory.GetClientFn()(ctx)
+	client, err = factory.GetClientFn()(ctx, "")
 	assert.NoError(t, err)
 	assert.NotEqual(t, authClient, client)
 
 	// Test missing context info
 	ctx = context.Background()
-	client, err = factory.GetClientFn()(ctx)
+	client, err = factory.GetClientFn()(ctx, "")
 	assert.NoError(t, err)
 	assert.Equal(t, authClient, client) // Should default to auth client
 }

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -57,7 +57,7 @@ func GetCommit(getClient GetClientFn, t translations.TranslationHelperFunc) (too
 				PerPage: pagination.perPage,
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -131,7 +131,7 @@ func ListCommits(getClient GetClientFn, t translations.TranslationHelperFunc) (t
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -200,7 +200,7 @@ func ListBranches(getClient GetClientFn, t translations.TranslationHelperFunc) (
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -310,7 +310,7 @@ func CreateOrUpdateFile(getClient GetClientFn, t translations.TranslationHelperF
 			}
 
 			// Create or update the file
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -384,7 +384,7 @@ func CreateRepository(getClient GetClientFn, t translations.TranslationHelperFun
 				AutoInit:    github.Ptr(autoInit),
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -456,7 +456,7 @@ func GetFileContents(getClient GetClientFn, t translations.TranslationHelperFunc
 			// Add repository info to context for client selection
 			ctx = WithRepoContext(ctx, owner, repo)
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -530,7 +530,7 @@ func ForkRepository(getClient GetClientFn, t translations.TranslationHelperFunc)
 				opts.Organization = org
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -619,7 +619,7 @@ func DeleteFile(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -764,7 +764,7 @@ func CreateBranch(getClient GetClientFn, t translations.TranslationHelperFunc) (
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -880,7 +880,7 @@ func PushFiles(getClient GetClientFn, t translations.TranslationHelperFunc) (too
 				return mcp.NewToolResultError("files parameter must be an array of objects with path and content"), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -1000,7 +1000,7 @@ func ListTags(getClient GetClientFn, t translations.TranslationHelperFunc) (tool
 				PerPage: pagination.perPage,
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -1063,7 +1063,7 @@ func GetTag(getClient GetClientFn, t translations.TranslationHelperFunc) (tool m
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}

--- a/pkg/github/repository_resource.go
+++ b/pkg/github/repository_resource.go
@@ -110,7 +110,7 @@ func RepositoryResourceContentsHandler(getClient GetClientFn) func(ctx context.C
 			opts.Ref = "refs/pull/" + prNumber[0] + "/head"
 		}
 
-		client, err := getClient(ctx)
+		client, err := getClient(ctx, owner)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 		}

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -40,7 +40,9 @@ func SearchRepositories(getClient GetClientFn, t translations.TranslationHelperF
 			// This is a simple heuristic to check if the query contains a specific repository
 			// Format could be "repo:owner/repo" or similar
 			repoQuery := extractRepoFromQuery(query)
+			owner := ""
 			if repoQuery.owner != "" && repoQuery.repo != "" {
+				owner = repoQuery.owner
 				ctx = WithRepoContext(ctx, repoQuery.owner, repoQuery.repo)
 			}
 
@@ -51,7 +53,7 @@ func SearchRepositories(getClient GetClientFn, t translations.TranslationHelperF
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -119,7 +121,9 @@ func SearchCode(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 
 			// Extract repository info if present in the query
 			repoQuery := extractRepoFromQuery(query)
+			owner := ""
 			if repoQuery.owner != "" && repoQuery.repo != "" {
+				owner = repoQuery.owner
 				ctx = WithRepoContext(ctx, repoQuery.owner, repoQuery.repo)
 			}
 
@@ -132,7 +136,7 @@ func SearchCode(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -209,7 +213,7 @@ func SearchUsers(getClient GetClientFn, t translations.TranslationHelperFunc) (t
 				},
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}

--- a/pkg/github/secret_scanning.go
+++ b/pkg/github/secret_scanning.go
@@ -48,7 +48,7 @@ func GetSecretScanningAlert(getClient GetClientFn, t translations.TranslationHel
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
@@ -126,7 +126,7 @@ func ListSecretScanningAlerts(getClient GetClientFn, t translations.TranslationH
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			client, err := getClient(ctx)
+			client, err := getClient(ctx, owner)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}

--- a/pkg/github/server_test.go
+++ b/pkg/github/server_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func stubGetClientFn(client *github.Client) GetClientFn {
-	return func(_ context.Context) (*github.Client, error) {
+	return func(_ context.Context, _ string) (*github.Client, error) {
 		return client, nil
 	}
 }
 
 func stubGetGQLClientFn(client *githubv4.Client) GetGQLClientFn {
-	return func(_ context.Context) (*githubv4.Client, error) {
+	return func(_ context.Context, _ string) (*githubv4.Client, error) {
 		return client, nil
 	}
 }

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -11,8 +11,8 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-type GetClientFn func(context.Context) (*github.Client, error)
-type GetGQLClientFn func(context.Context) (*githubv4.Client, error)
+type GetClientFn func(ctx context.Context, owner string) (*github.Client, error)
+type GetGQLClientFn func(ctx context.Context, owner string) (*githubv4.Client, error)
 
 var DefaultTools = []string{"all"}
 

--- a/pkg/github/tools_test.go
+++ b/pkg/github/tools_test.go
@@ -66,10 +66,10 @@ func TestInitToolsetsWithConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Mock client functions
-			getClient := func(ctx context.Context) (*github.Client, error) {
+			getClient := func(ctx context.Context, _ string) (*github.Client, error) {
 				return nil, nil
 			}
-			getGQLClient := func(ctx context.Context) (*githubv4.Client, error) {
+			getGQLClient := func(ctx context.Context, _ string) (*githubv4.Client, error) {
 				return nil, nil
 			}
 
@@ -119,10 +119,10 @@ func TestInitToolsets_BackwardCompatibility(t *testing.T) {
 	}
 
 	// Mock client functions
-	getClient := func(ctx context.Context) (*github.Client, error) {
+	getClient := func(ctx context.Context, _ string) (*github.Client, error) {
 		return nil, nil
 	}
-	getGQLClient := func(ctx context.Context) (*githubv4.Client, error) {
+	getGQLClient := func(ctx context.Context, _ string) (*githubv4.Client, error) {
 		return nil, nil
 	}
 
@@ -201,10 +201,10 @@ func TestToolsetModeFiltering(t *testing.T) {
 	}
 
 	// Mock client functions
-	getClient := func(ctx context.Context) (*github.Client, error) {
+	getClient := func(ctx context.Context, _ string) (*github.Client, error) {
 		return nil, nil
 	}
-	getGQLClient := func(ctx context.Context) (*githubv4.Client, error) {
+	getGQLClient := func(ctx context.Context, _ string) (*githubv4.Client, error) {
 		return nil, nil
 	}
 
@@ -326,10 +326,10 @@ func TestContextToolsetIntegration(t *testing.T) {
 	}
 
 	// Mock client functions
-	getClient := func(ctx context.Context) (*github.Client, error) {
+	getClient := func(ctx context.Context, _ string) (*github.Client, error) {
 		return nil, nil
 	}
-	getGQLClient := func(ctx context.Context) (*githubv4.Client, error) {
+	getGQLClient := func(ctx context.Context, _ string) (*githubv4.Client, error) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary

Enables the GitHub MCP server to work with repositories across multiple GitHub organizations by supporting per-org GitHub App installation tokens.

**Key changes:**
- Parse `GITHUB_INSTALLATION_ID_<ORG>` environment variables for per-org installation IDs
- New `MultiOrgClientFactory` that creates authenticated clients per organization
- Updated `GetClientFn` signature to accept `owner` parameter
- All ~40 tool handlers updated to pass owner to client factory
- Backwards compatible: falls back to `GITHUB_INSTALLATION_ID` if no org-specific ID configured

## Environment Variables

| Variable | Purpose |
|----------|---------|
| `GITHUB_INSTALLATION_ID_SQUAREUP` | squareup org installation ID |
| `GITHUB_INSTALLATION_ID_AFTERPAYTOUCH` | AfterpayTouch org installation ID |
| `GITHUB_INSTALLATION_ID` | Fallback (backwards compatibility) |

## Test plan

- [x] Build: `go build ./cmd/...`
- [x] Tests: `go test ./...`
- [x] Manual test with multi-org env vars set

🤖 Generated with [Claude Code](https://claude.com/claude-code)