### PR TITLE
Add GITHUB_REPO_DENYLIST to block MCP access to confidential repos

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -47,6 +47,13 @@ var (
 				return fmt.Errorf("failed to unmarshal toolsets: %w", err)
 			}
 
+			// Same approach as toolsets: viper.GetStringSlice doesn't handle comma-separated
+			// env vars correctly, so UnmarshalKey is used instead.
+			var repoDenylist []string
+			if err := viper.UnmarshalKey("repo-denylist", &repoDenylist); err != nil {
+				return fmt.Errorf("failed to unmarshal repo denylist: %w", err)
+			}
+
 			// Parse multi-org installations
 			installations := parseOrgInstallations()
 
@@ -58,6 +65,7 @@ var (
 				DynamicToolsets:      viper.GetBool("dynamic_toolsets"),
 				ReadOnly:             viper.GetBool("read-only"),
 				WritePrivateOnly:     viper.GetBool("write-private-only"),
+				RepoDenylist:         repoDenylist,
 				ExportTranslations:   viper.GetBool("export-translations"),
 				EnableCommandLogging: viper.GetBool("enable-command-logging"),
 				LogFilePath:          viper.GetString("log-file"),
@@ -107,6 +115,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("dynamic-toolsets", false, "Enable dynamic toolsets")
 	rootCmd.PersistentFlags().Bool("read-only", false, "Restrict the server to read-only operations")
 	rootCmd.PersistentFlags().Bool("write-private-only", false, "Restrict all write operations to private repositories only")
+	rootCmd.PersistentFlags().StringSlice("repo-denylist", nil, "Comma-separated list of owner/repo patterns to block all access to (e.g. 'squareup/secret-repo,squareup/*')")
 	rootCmd.PersistentFlags().String("log-file", "", "Path to log file")
 	rootCmd.PersistentFlags().Bool("enable-command-logging", false, "When enabled, the server will log all command requests and responses to the log file")
 	rootCmd.PersistentFlags().Bool("export-translations", false, "Save translations to a JSON file")
@@ -125,6 +134,8 @@ func init() {
 	_ = viper.BindPFlag("read-only", rootCmd.PersistentFlags().Lookup("read-only"))
 	_ = viper.BindPFlag("write-private-only", rootCmd.PersistentFlags().Lookup("write-private-only"))
 	_ = viper.BindEnv("write-private-only", "GITHUB_WRITE_PRIVATE_ONLY")
+	_ = viper.BindPFlag("repo-denylist", rootCmd.PersistentFlags().Lookup("repo-denylist"))
+	_ = viper.BindEnv("repo-denylist", "GITHUB_REPO_DENYLIST")
 	_ = viper.BindPFlag("log-file", rootCmd.PersistentFlags().Lookup("log-file"))
 	_ = viper.BindPFlag("enable-command-logging", rootCmd.PersistentFlags().Lookup("enable-command-logging"))
 	_ = viper.BindPFlag("export-translations", rootCmd.PersistentFlags().Lookup("export-translations"))

--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -221,6 +221,11 @@ type MCPServerConfig struct {
 	// writes to public repositories. Has no effect when ReadOnly is also true.
 	WritePrivateOnly bool
 
+	// RepoDenylist is a list of "owner/repo" patterns (or "owner/*" wildcards) for
+	// repositories that must not be accessible via any tool or resource. Both reads
+	// and writes are blocked. Configured via GITHUB_REPO_DENYLIST.
+	RepoDenylist []string
+
 	// Installations maps organization names to GitHub App installation IDs
 	Installations map[string]int64
 
@@ -289,11 +294,18 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 	getClient := clientFactory.GetClientFn()
 	getGQLClient := clientFactory.GetGQLClientFn()
 
+	// Parse repo denylist
+	denylist := github.NewRepoDenylist(cfg.RepoDenylist)
+	if !denylist.IsEmpty() {
+		logrus.Infof("Repository denylist active: %d entries (GITHUB_REPO_DENYLIST)", len(cfg.RepoDenylist))
+	}
+
 	// Create default toolsets
 	toolsets, err := github.InitToolsets(
 		enabledToolsets,
 		cfg.ReadOnly,
 		cfg.WritePrivateOnly,
+		denylist,
 		getClient,
 		getGQLClient,
 		cfg.Translator,
@@ -310,7 +322,7 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 		}
 	}
 
-	github.RegisterResources(ghServer, getClient, cfg.Translator)
+	github.RegisterResources(ghServer, getClient, denylist, cfg.Translator)
 
 	// Register the tools with the server
 	toolsets.RegisterTools(ghServer)
@@ -347,6 +359,9 @@ type StdioServerConfig struct {
 	// WritePrivateOnly restricts all write operations to private repositories only.
 	WritePrivateOnly bool
 
+	// RepoDenylist is a list of "owner/repo" patterns (or "owner/*" wildcards) to block.
+	RepoDenylist []string
+
 	// ExportTranslations indicates if we should export translations
 	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#i18n--overriding-descriptions
 	ExportTranslations bool
@@ -377,6 +392,7 @@ func RunStdioServer(cfg StdioServerConfig) error {
 		DynamicToolsets:  cfg.DynamicToolsets,
 		ReadOnly:         cfg.ReadOnly,
 		WritePrivateOnly: cfg.WritePrivateOnly,
+		RepoDenylist:     cfg.RepoDenylist,
 		Installations:    cfg.Installations,
 		Translator:       t,
 	})

--- a/pkg/github/query_helpers.go
+++ b/pkg/github/query_helpers.go
@@ -5,18 +5,24 @@ import (
 	"strings"
 )
 
+var (
+	repoQualifierPattern      = regexp.MustCompile(`repo:([^/\s]+)/([^/\s]+)`)
+	bareOwnerRepoPattern      = regexp.MustCompile(`\b([^/\s]+)/([^/\s]+)\b`)
+	orgOrUserQualifierPattern = regexp.MustCompile(`(?:org|user):([^\s]+)`)
+)
+
 // repoQueryInfo holds extracted repository information from a query
 type repoQueryInfo struct {
 	owner string
 	repo  string
 }
 
-// extractRepoFromQuery attempts to extract repository owner and name from a search query
-// It looks for patterns like "repo:owner/repo" or "owner/repo"
+// extractRepoFromQuery attempts to extract the first repository owner and name from a
+// search query. It looks for patterns like "repo:owner/repo" or bare "owner/repo".
+// Use extractAllReposFromQuery when checking a denylist to catch multiple repo: qualifiers.
 func extractRepoFromQuery(query string) repoQueryInfo {
 	// Check for repo:owner/repo pattern
-	repoPattern := regexp.MustCompile(`repo:([^/\s]+)/([^/\s]+)`)
-	matches := repoPattern.FindStringSubmatch(query)
+	matches := repoQualifierPattern.FindStringSubmatch(query)
 	if len(matches) == 3 {
 		return repoQueryInfo{
 			owner: matches[1],
@@ -24,9 +30,8 @@ func extractRepoFromQuery(query string) repoQueryInfo {
 		}
 	}
 
-	// Check for owner/repo pattern
-	ownerRepoPattern := regexp.MustCompile(`\b([^/\s]+)/([^/\s]+)\b`)
-	matches = ownerRepoPattern.FindStringSubmatch(query)
+	// Check for bare owner/repo pattern
+	matches = bareOwnerRepoPattern.FindStringSubmatch(query)
 	if len(matches) == 3 {
 		// Make sure it's not part of another pattern
 		if !strings.Contains(query, "repo:"+matches[0]) {
@@ -40,11 +45,24 @@ func extractRepoFromQuery(query string) repoQueryInfo {
 	return repoQueryInfo{}
 }
 
+// extractAllReposFromQuery returns all "repo:owner/repo" qualifiers found in the query.
+// Used by denylist enforcement to prevent bypass via multiple repo: qualifiers
+// (e.g. "repo:allowed/repo repo:denied/repo").
+func extractAllReposFromQuery(query string) []repoQueryInfo {
+	matches := repoQualifierPattern.FindAllStringSubmatch(query, -1)
+	results := make([]repoQueryInfo, 0, len(matches))
+	for _, m := range matches {
+		if len(m) == 3 {
+			results = append(results, repoQueryInfo{owner: m[1], repo: m[2]})
+		}
+	}
+	return results
+}
+
 // extractOrgFromQuery attempts to extract an organization or user name from a search query.
 // It looks for patterns like "org:squareup" or "user:octocat".
 func extractOrgFromQuery(query string) string {
-	orgPattern := regexp.MustCompile(`(?:org|user):([^\s]+)`)
-	matches := orgPattern.FindStringSubmatch(query)
+	matches := orgOrUserQualifierPattern.FindStringSubmatch(query)
 	if len(matches) == 2 {
 		return matches[1]
 	}

--- a/pkg/github/repo_denylist.go
+++ b/pkg/github/repo_denylist.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"strings"
+)
+
+// RepoDenylist holds parsed denylist entries for efficient lookup.
+// Supports exact matches ("owner/repo") and org-level wildcards ("owner/*").
+type RepoDenylist struct {
+	repos map[string]bool // exact "owner/repo" entries (lowercased)
+	orgs  map[string]bool // org wildcard entries — "owner" when "owner/*" is configured (lowercased)
+}
+
+// NewRepoDenylist parses a slice of denylist entries into a RepoDenylist.
+// Entries must be "owner/repo" (exact) or "owner/*" (org wildcard).
+// Entries are normalized to lowercase. Invalid entries are silently skipped.
+func NewRepoDenylist(entries []string) *RepoDenylist {
+	d := &RepoDenylist{
+		repos: make(map[string]bool),
+		orgs:  make(map[string]bool),
+	}
+	for _, entry := range entries {
+		entry = strings.TrimSpace(strings.ToLower(entry))
+		if entry == "" {
+			continue
+		}
+		parts := strings.SplitN(entry, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		owner, repo := parts[0], parts[1]
+		if repo == "*" {
+			d.orgs[owner] = true
+		} else {
+			d.repos[owner+"/"+repo] = true
+		}
+	}
+	return d
+}
+
+// IsDenied reports whether the given owner/repo combination is on the denylist.
+// Checks exact match first, then org wildcard. Case-insensitive.
+// Safe to call on a nil *RepoDenylist (always returns false).
+func (d *RepoDenylist) IsDenied(owner, repo string) bool {
+	if d == nil {
+		return false
+	}
+	key := strings.ToLower(owner) + "/" + strings.ToLower(repo)
+	if d.repos[key] {
+		return true
+	}
+	return d.orgs[strings.ToLower(owner)]
+}
+
+// IsOrgDenied reports whether all repos under the given org are denied
+// (i.e., an "owner/*" wildcard entry exists). Used for search query pre-checks.
+// Safe to call on a nil *RepoDenylist (always returns false).
+func (d *RepoDenylist) IsOrgDenied(org string) bool {
+	if d == nil {
+		return false
+	}
+	return d.orgs[strings.ToLower(org)]
+}
+
+// IsEmpty reports whether the denylist has no entries.
+// Safe to call on a nil *RepoDenylist (returns true).
+func (d *RepoDenylist) IsEmpty() bool {
+	if d == nil {
+		return true
+	}
+	return len(d.repos) == 0 && len(d.orgs) == 0
+}

--- a/pkg/github/repo_denylist_guard.go
+++ b/pkg/github/repo_denylist_guard.go
@@ -56,8 +56,10 @@ func SearchDenylistGuard(denylist *RepoDenylist, queryParam string, tool mcp.Too
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		// Block if the query targets a denied repo via "repo:owner/repo"
-		if info := extractRepoFromQuery(query); info.owner != "" && info.repo != "" {
+		// Block if any "repo:owner/repo" qualifier in the query targets a denied repo.
+		// All qualifiers are checked to prevent bypass via multiple repo: qualifiers
+		// (e.g. "repo:allowed/repo repo:denied/repo").
+		for _, info := range extractAllReposFromQuery(query) {
 			if denylist.IsDenied(info.owner, info.repo) {
 				logrus.Warnf("Search blocked: %s targeting denied repo %s/%s (GITHUB_REPO_DENYLIST)",
 					tool.Name, info.owner, info.repo)
@@ -96,7 +98,7 @@ func DenylistResourceGuard(denylist *RepoDenylist, handler server.ResourceTempla
 				if denylist.IsDenied(owner, repo) {
 					logrus.Warnf("Resource access blocked: %s/%s is on the denylist (GITHUB_REPO_DENYLIST)", owner, repo)
 					return nil, fmt.Errorf(
-						"access blocked: %s/%s is on the repository denylist. "+
+						"Access blocked: %s/%s is on the repository denylist. "+
 							"Contact the administrator if you believe this is an error.",
 						owner, repo,
 					)

--- a/pkg/github/repo_denylist_guard.go
+++ b/pkg/github/repo_denylist_guard.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/sirupsen/logrus"
+)
+
+// RepoDenylistGuard wraps a tool handler to enforce GITHUB_REPO_DENYLIST.
+// It extracts owner and repo from the MCP request and blocks both reads and
+// writes if the repository matches the denylist. Runs before other guards
+// (e.g. WritePrivateOnlyGuard) so denied repos are rejected without making
+// any GitHub API calls.
+func RepoDenylistGuard(denylist *RepoDenylist, tool mcp.Tool, handler server.ToolHandlerFunc) (mcp.Tool, server.ToolHandlerFunc) {
+	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		owner, err := requiredParam[string](req, "owner")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		repo, err := requiredParam[string](req, "repo")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		if denylist.IsDenied(owner, repo) {
+			logrus.Warnf("Access blocked: %s on denied repo %s/%s (GITHUB_REPO_DENYLIST)", tool.Name, owner, repo)
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"Access blocked: %s/%s is on the repository denylist. "+
+					"The server is configured with GITHUB_REPO_DENYLIST, which restricts "+
+					"all operations on specified repositories. "+
+					"Contact the administrator if you believe this is an error.",
+				owner, repo,
+			)), nil
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// SearchDenylistGuard wraps a search tool handler to block queries that
+// explicitly target a denied repository or organization. queryParam is the
+// name of the string parameter holding the search query (e.g. "query" or "q").
+//
+// Uses extractRepoFromQuery and extractOrgFromQuery from query_helpers.go to
+// detect "repo:owner/repo" and "org:owner" / "user:owner" qualifiers.
+// Unscoped searches that happen to return results from denied repos are not
+// filtered — any follow-up tool call (e.g. get_file_contents) will be blocked
+// by RepoDenylistGuard.
+func SearchDenylistGuard(denylist *RepoDenylist, queryParam string, tool mcp.Tool, handler server.ToolHandlerFunc) (mcp.Tool, server.ToolHandlerFunc) {
+	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		query, err := requiredParam[string](req, queryParam)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		// Block if the query targets a denied repo via "repo:owner/repo"
+		if info := extractRepoFromQuery(query); info.owner != "" && info.repo != "" {
+			if denylist.IsDenied(info.owner, info.repo) {
+				logrus.Warnf("Search blocked: %s targeting denied repo %s/%s (GITHUB_REPO_DENYLIST)",
+					tool.Name, info.owner, info.repo)
+				return mcp.NewToolResultError(fmt.Sprintf(
+					"Search blocked: the query targets %s/%s, which is on the repository denylist. "+
+						"Contact the administrator if you believe this is an error.",
+					info.owner, info.repo,
+				)), nil
+			}
+		}
+
+		// Block if the query targets a denied org via "org:owner" or "user:owner"
+		if org := extractOrgFromQuery(query); org != "" && denylist.IsOrgDenied(org) {
+			logrus.Warnf("Search blocked: %s targeting denied org %s (GITHUB_REPO_DENYLIST)", tool.Name, org)
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"Search blocked: the query targets organization %s, all of whose repositories "+
+					"are on the denylist. Contact the administrator if you believe this is an error.",
+				org,
+			)), nil
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// DenylistResourceGuard wraps a resource template handler to enforce
+// GITHUB_REPO_DENYLIST for repo:// URI resource requests. Extracts owner
+// and repo from the resource request arguments (same as RepositoryResourceContentsHandler).
+func DenylistResourceGuard(denylist *RepoDenylist, handler server.ResourceTemplateHandlerFunc) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		o, ok := request.Params.Arguments["owner"].([]string)
+		if ok && len(o) > 0 {
+			r, ok := request.Params.Arguments["repo"].([]string)
+			if ok && len(r) > 0 {
+				owner, repo := o[0], r[0]
+				if denylist.IsDenied(owner, repo) {
+					logrus.Warnf("Resource access blocked: %s/%s is on the denylist (GITHUB_REPO_DENYLIST)", owner, repo)
+					return nil, fmt.Errorf(
+						"access blocked: %s/%s is on the repository denylist. "+
+							"Contact the administrator if you believe this is an error.",
+						owner, repo,
+					)
+				}
+			}
+		}
+		return handler(ctx, request)
+	}
+}

--- a/pkg/github/repo_denylist_guard_test.go
+++ b/pkg/github/repo_denylist_guard_test.go
@@ -1,0 +1,224 @@
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RepoDenylistGuard(t *testing.T) {
+	tests := []struct {
+		name           string
+		denylist       *RepoDenylist
+		requestArgs    map[string]interface{}
+		expectBlocked  bool
+		expectedErrMsg string
+	}{
+		{
+			name:        "passes through when repo is not denied",
+			denylist:    NewRepoDenylist([]string{"squareup/infosec-minesweeper"}),
+			requestArgs: map[string]interface{}{"owner": "squareup", "repo": "goosed-slackbot"},
+		},
+		{
+			name:           "blocks exact match",
+			denylist:       NewRepoDenylist([]string{"squareup/infosec-minesweeper"}),
+			requestArgs:    map[string]interface{}{"owner": "squareup", "repo": "infosec-minesweeper"},
+			expectBlocked:  true,
+			expectedErrMsg: "Access blocked: squareup/infosec-minesweeper is on the repository denylist",
+		},
+		{
+			name:           "blocks org wildcard match",
+			denylist:       NewRepoDenylist([]string{"squareup/*"}),
+			requestArgs:    map[string]interface{}{"owner": "squareup", "repo": "any-repo"},
+			expectBlocked:  true,
+			expectedErrMsg: "Access blocked: squareup/any-repo is on the repository denylist",
+		},
+		{
+			name:           "blocks case-insensitively",
+			denylist:       NewRepoDenylist([]string{"squareup/infosec-minesweeper"}),
+			requestArgs:    map[string]interface{}{"owner": "SquareUp", "repo": "Infosec-Minesweeper"},
+			expectBlocked:  true,
+			expectedErrMsg: "Access blocked: SquareUp/Infosec-Minesweeper is on the repository denylist",
+		},
+		{
+			name:        "passes through when denylist is empty",
+			denylist:    NewRepoDenylist([]string{}),
+			requestArgs: map[string]interface{}{"owner": "squareup", "repo": "infosec-minesweeper"},
+		},
+		{
+			name:           "returns error when owner param is missing",
+			denylist:       NewRepoDenylist([]string{"squareup/infosec-minesweeper"}),
+			requestArgs:    map[string]interface{}{"repo": "infosec-minesweeper"},
+			expectBlocked:  true,
+			expectedErrMsg: "missing required parameter: owner",
+		},
+		{
+			name:           "returns error when repo param is missing",
+			denylist:       NewRepoDenylist([]string{"squareup/infosec-minesweeper"}),
+			requestArgs:    map[string]interface{}{"owner": "squareup"},
+			expectBlocked:  true,
+			expectedErrMsg: "missing required parameter: repo",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := dummyTool("test_tool")
+			_, guardedHandler := RepoDenylistGuard(tc.denylist, tool, dummyWriteHandler)
+
+			result, err := guardedHandler(context.Background(), createMCPRequest(tc.requestArgs))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			text := getTextResult(t, result)
+			if tc.expectBlocked {
+				assert.True(t, result.IsError)
+				assert.Contains(t, text.Text, tc.expectedErrMsg)
+			} else {
+				assert.False(t, result.IsError, "expected pass-through, got: %s", text.Text)
+				assert.Equal(t, "write succeeded", text.Text)
+			}
+		})
+	}
+}
+
+func Test_SearchDenylistGuard(t *testing.T) {
+	denylist := NewRepoDenylist([]string{"squareup/infosec-minesweeper", "afterpaytouch/*"})
+
+	tests := []struct {
+		name           string
+		queryParam     string
+		query          string
+		expectBlocked  bool
+		expectedErrMsg string
+	}{
+		{
+			name:       "passes through unrelated query",
+			queryParam: "q",
+			query:      "some search term",
+		},
+		{
+			name:           "blocks repo: qualifier targeting denied repo",
+			queryParam:     "q",
+			query:          "repo:squareup/infosec-minesweeper secret",
+			expectBlocked:  true,
+			expectedErrMsg: "Search blocked: the query targets squareup/infosec-minesweeper",
+		},
+		{
+			name:           "blocks org: qualifier targeting denied org",
+			queryParam:     "q",
+			query:          "org:afterpaytouch authentication",
+			expectBlocked:  true,
+			expectedErrMsg: "Search blocked: the query targets organization afterpaytouch",
+		},
+		{
+			name:       "passes through org: qualifier for non-denied org",
+			queryParam: "q",
+			query:      "org:squareup some-term",
+		},
+		{
+			name:       "passes through repo: qualifier targeting non-denied repo",
+			queryParam: "q",
+			query:      "repo:squareup/goosed-slackbot something",
+		},
+		{
+			name:       "passes through query with no qualifiers",
+			queryParam: "query",
+			query:      "repositories about authentication",
+		},
+		{
+			name:           "blocks user: qualifier targeting denied org",
+			queryParam:     "q",
+			query:          "user:afterpaytouch something",
+			expectBlocked:  true,
+			expectedErrMsg: "Search blocked: the query targets organization afterpaytouch",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := dummyTool("search_tool")
+			args := map[string]interface{}{tc.queryParam: tc.query}
+			_, guardedHandler := SearchDenylistGuard(denylist, tc.queryParam, tool, dummyWriteHandler)
+
+			result, err := guardedHandler(context.Background(), createMCPRequest(args))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			text := getTextResult(t, result)
+			if tc.expectBlocked {
+				assert.True(t, result.IsError)
+				assert.Contains(t, text.Text, tc.expectedErrMsg)
+			} else {
+				assert.False(t, result.IsError, "expected pass-through, got: %s", text.Text)
+				assert.Equal(t, "write succeeded", text.Text)
+			}
+		})
+	}
+}
+
+func Test_DenylistResourceGuard(t *testing.T) {
+	dummyResourceHandler := func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return []mcp.ResourceContents{mcp.TextResourceContents{URI: "repo://ok", Text: "content"}}, nil
+	}
+
+	tests := []struct {
+		name          string
+		denylist      *RepoDenylist
+		owner         string
+		repo          string
+		expectBlocked bool
+	}{
+		{
+			name:     "passes through when repo is not denied",
+			denylist: NewRepoDenylist([]string{"squareup/infosec-minesweeper"}),
+			owner:    "squareup",
+			repo:     "goosed-slackbot",
+		},
+		{
+			name:          "blocks denied repo",
+			denylist:      NewRepoDenylist([]string{"squareup/infosec-minesweeper"}),
+			owner:         "squareup",
+			repo:          "infosec-minesweeper",
+			expectBlocked: true,
+		},
+		{
+			name:          "blocks org wildcard",
+			denylist:      NewRepoDenylist([]string{"squareup/*"}),
+			owner:         "squareup",
+			repo:          "any-repo",
+			expectBlocked: true,
+		},
+		{
+			name:     "passes through when denylist is empty",
+			denylist: NewRepoDenylist(nil),
+			owner:    "squareup",
+			repo:     "infosec-minesweeper",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			guarded := DenylistResourceGuard(tc.denylist, dummyResourceHandler)
+
+			req := mcp.ReadResourceRequest{}
+			req.Params.Arguments = map[string]interface{}{
+				"owner": []string{tc.owner},
+				"repo":  []string{tc.repo},
+			}
+
+			contents, err := guarded(context.Background(), req)
+			if tc.expectBlocked {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "access blocked")
+				assert.Nil(t, contents)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, contents)
+			}
+		})
+	}
+}

--- a/pkg/github/repo_denylist_guard_test.go
+++ b/pkg/github/repo_denylist_guard_test.go
@@ -130,6 +130,13 @@ func Test_SearchDenylistGuard(t *testing.T) {
 			query:      "repositories about authentication",
 		},
 		{
+			name:           "blocks second repo: qualifier when first is allowed (multi-qualifier bypass)",
+			queryParam:     "q",
+			query:          "repo:squareup/goosed-slackbot repo:squareup/infosec-minesweeper something",
+			expectBlocked:  true,
+			expectedErrMsg: "Search blocked: the query targets squareup/infosec-minesweeper",
+		},
+		{
 			name:           "blocks user: qualifier targeting denied org",
 			queryParam:     "q",
 			query:          "user:afterpaytouch something",
@@ -213,7 +220,7 @@ func Test_DenylistResourceGuard(t *testing.T) {
 			contents, err := guarded(context.Background(), req)
 			if tc.expectBlocked {
 				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "access blocked")
+				assert.Contains(t, err.Error(), "Access blocked")
 				assert.Nil(t, contents)
 			} else {
 				assert.NoError(t, err)

--- a/pkg/github/repo_denylist_test.go
+++ b/pkg/github/repo_denylist_test.go
@@ -1,0 +1,138 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRepoDenylist_IsDenied(t *testing.T) {
+	tests := []struct {
+		name     string
+		entries  []string
+		owner    string
+		repo     string
+		expected bool
+	}{
+		{
+			name:     "exact match is denied",
+			entries:  []string{"squareup/infosec-minesweeper"},
+			owner:    "squareup",
+			repo:     "infosec-minesweeper",
+			expected: true,
+		},
+		{
+			name:     "non-denied repo is allowed",
+			entries:  []string{"squareup/infosec-minesweeper"},
+			owner:    "squareup",
+			repo:     "goosed-slackbot",
+			expected: false,
+		},
+		{
+			name:     "org wildcard denies any repo under org",
+			entries:  []string{"squareup/*"},
+			owner:    "squareup",
+			repo:     "any-repo",
+			expected: true,
+		},
+		{
+			name:     "org wildcard does not affect other orgs",
+			entries:  []string{"squareup/*"},
+			owner:    "otherorg",
+			repo:     "any-repo",
+			expected: false,
+		},
+		{
+			name:     "case-insensitive owner match",
+			entries:  []string{"SquareUp/infosec-minesweeper"},
+			owner:    "squareup",
+			repo:     "infosec-minesweeper",
+			expected: true,
+		},
+		{
+			name:     "case-insensitive repo match",
+			entries:  []string{"squareup/Infosec-Minesweeper"},
+			owner:    "squareup",
+			repo:     "infosec-minesweeper",
+			expected: true,
+		},
+		{
+			name:     "case-insensitive input",
+			entries:  []string{"squareup/infosec-minesweeper"},
+			owner:    "SquareUp",
+			repo:     "Infosec-Minesweeper",
+			expected: true,
+		},
+		{
+			name:     "empty denylist allows everything",
+			entries:  []string{},
+			owner:    "squareup",
+			repo:     "any-repo",
+			expected: false,
+		},
+		{
+			name:     "whitespace around entries is trimmed",
+			entries:  []string{"  squareup/infosec-minesweeper  "},
+			owner:    "squareup",
+			repo:     "infosec-minesweeper",
+			expected: true,
+		},
+		{
+			name:     "comma-separated entries parsed correctly (multiple)",
+			entries:  []string{"squareup/infosec-minesweeper", "squareup/cax-regulatory"},
+			owner:    "squareup",
+			repo:     "cax-regulatory",
+			expected: true,
+		},
+		{
+			name:     "invalid entry without slash is skipped",
+			entries:  []string{"noslash", "squareup/valid-repo"},
+			owner:    "squareup",
+			repo:     "valid-repo",
+			expected: true,
+		},
+		{
+			name:     "empty string entries are skipped",
+			entries:  []string{"", "squareup/infosec-minesweeper"},
+			owner:    "squareup",
+			repo:     "infosec-minesweeper",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewRepoDenylist(tc.entries)
+			assert.Equal(t, tc.expected, d.IsDenied(tc.owner, tc.repo))
+		})
+	}
+}
+
+func TestRepoDenylist_NilSafe(t *testing.T) {
+	var d *RepoDenylist
+	assert.False(t, d.IsDenied("squareup", "any-repo"))
+	assert.False(t, d.IsOrgDenied("squareup"))
+	assert.True(t, d.IsEmpty())
+}
+
+func TestRepoDenylist_IsEmpty(t *testing.T) {
+	assert.True(t, NewRepoDenylist(nil).IsEmpty())
+	assert.True(t, NewRepoDenylist([]string{}).IsEmpty())
+	assert.True(t, NewRepoDenylist([]string{"", "  "}).IsEmpty())
+	assert.False(t, NewRepoDenylist([]string{"squareup/repo"}).IsEmpty())
+	assert.False(t, NewRepoDenylist([]string{"squareup/*"}).IsEmpty())
+}
+
+func TestRepoDenylist_IsOrgDenied(t *testing.T) {
+	d := NewRepoDenylist([]string{"squareup/*", "afterpaytouch/specific-repo"})
+
+	// Org wildcard entry
+	assert.True(t, d.IsOrgDenied("squareup"))
+	assert.True(t, d.IsOrgDenied("SquareUp")) // case-insensitive
+
+	// Exact entry does not make the whole org denied
+	assert.False(t, d.IsOrgDenied("afterpaytouch"))
+
+	// Unrelated org
+	assert.False(t, d.IsOrgDenied("someotherorg"))
+}

--- a/pkg/github/resources.go
+++ b/pkg/github/resources.go
@@ -2,13 +2,21 @@ package github
 
 import (
 	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
-func RegisterResources(s *server.MCPServer, getClient GetClientFn, t translations.TranslationHelperFunc) {
-	s.AddResourceTemplate(GetRepositoryResourceContent(getClient, t))
-	s.AddResourceTemplate(GetRepositoryResourceBranchContent(getClient, t))
-	s.AddResourceTemplate(GetRepositoryResourceCommitContent(getClient, t))
-	s.AddResourceTemplate(GetRepositoryResourceTagContent(getClient, t))
-	s.AddResourceTemplate(GetRepositoryResourcePrContent(getClient, t))
+func RegisterResources(s *server.MCPServer, getClient GetClientFn, denylist *RepoDenylist, t translations.TranslationHelperFunc) {
+	wrap := func(tmpl mcp.ResourceTemplate, handler server.ResourceTemplateHandlerFunc) (mcp.ResourceTemplate, server.ResourceTemplateHandlerFunc) {
+		if denylist != nil && !denylist.IsEmpty() {
+			return tmpl, DenylistResourceGuard(denylist, handler)
+		}
+		return tmpl, handler
+	}
+
+	s.AddResourceTemplate(wrap(GetRepositoryResourceContent(getClient, t)))
+	s.AddResourceTemplate(wrap(GetRepositoryResourceBranchContent(getClient, t)))
+	s.AddResourceTemplate(wrap(GetRepositoryResourceCommitContent(getClient, t)))
+	s.AddResourceTemplate(wrap(GetRepositoryResourceTagContent(getClient, t)))
+	s.AddResourceTemplate(wrap(GetRepositoryResourcePrContent(getClient, t)))
 }

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -17,22 +17,40 @@ type GetGQLClientFn func(ctx context.Context, owner string) (*githubv4.Client, e
 
 var DefaultTools = []string{"all"}
 
-func InitToolsets(passedToolsets []string, readOnly bool, writePrivateOnly bool, getClient GetClientFn, getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (*toolsets.ToolsetGroup, error) {
+func InitToolsets(passedToolsets []string, readOnly bool, writePrivateOnly bool, denylist *RepoDenylist, getClient GetClientFn, getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (*toolsets.ToolsetGroup, error) {
 	// Parse toolset configurations from the passed toolsets
 	configs, err := toolsets.ParseToolsetConfigFromSlice(passedToolsets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse toolset configuration: %w", err)
 	}
 
-	return InitToolsetsWithConfig(configs, readOnly, writePrivateOnly, getClient, getGQLClient, t)
+	return InitToolsetsWithConfig(configs, readOnly, writePrivateOnly, denylist, getClient, getGQLClient, t)
 }
 
-func InitToolsetsWithConfig(configs []toolsets.ToolsetConfig, readOnly bool, writePrivateOnly bool, getClient GetClientFn, getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (*toolsets.ToolsetGroup, error) {
+func InitToolsetsWithConfig(configs []toolsets.ToolsetConfig, readOnly bool, writePrivateOnly bool, denylist *RepoDenylist, getClient GetClientFn, getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (*toolsets.ToolsetGroup, error) {
 	// Create a new toolset group
 	tsg := toolsets.NewToolsetGroup(readOnly)
 
-	// Helper functions to conditionally wrap write tool handlers with guards.
-	// When writePrivateOnly=false, these are no-ops that return the tool and handler unchanged.
+	// Helper functions to conditionally wrap tool handlers with guards.
+	// When the relevant feature is disabled, these are no-ops returning the tool and handler unchanged.
+
+	// guardDenylist wraps any tool with owner+repo params to block denied repos (reads and writes).
+	// Runs outermost so denied repos are rejected before any other guard or API call.
+	guardDenylist := func(tool mcp.Tool, handler server.ToolHandlerFunc) (mcp.Tool, server.ToolHandlerFunc) {
+		if denylist != nil && !denylist.IsEmpty() {
+			return RepoDenylistGuard(denylist, tool, handler)
+		}
+		return tool, handler
+	}
+	// guardSearchDenylist wraps search tools to block queries explicitly targeting denied repos/orgs.
+	guardSearchDenylist := func(queryParam string) func(mcp.Tool, server.ToolHandlerFunc) (mcp.Tool, server.ToolHandlerFunc) {
+		return func(tool mcp.Tool, handler server.ToolHandlerFunc) (mcp.Tool, server.ToolHandlerFunc) {
+			if denylist != nil && !denylist.IsEmpty() {
+				return SearchDenylistGuard(denylist, queryParam, tool, handler)
+			}
+			return tool, handler
+		}
+	}
 	guardWrite := func(tool mcp.Tool, handler server.ToolHandlerFunc) (mcp.Tool, server.ToolHandlerFunc) {
 		if writePrivateOnly {
 			return WritePrivateOnlyGuard(getClient, tool, handler)
@@ -56,34 +74,34 @@ func InitToolsetsWithConfig(configs []toolsets.ToolsetConfig, readOnly bool, wri
 	// Create toolsets
 	repos := toolsets.NewToolset("repos", "GitHub Repository related tools").
 		AddReadTools(
-			toolsets.NewServerTool(SearchRepositories(getClient, t)),
-			toolsets.NewServerTool(GetFileContents(getClient, t)),
-			toolsets.NewServerTool(ListCommits(getClient, t)),
-			toolsets.NewServerTool(SearchCode(getClient, t)),
-			toolsets.NewServerTool(GetCommit(getClient, t)),
-			toolsets.NewServerTool(ListBranches(getClient, t)),
-			toolsets.NewServerTool(ListTags(getClient, t)),
-			toolsets.NewServerTool(GetTag(getClient, t)),
+			toolsets.NewServerTool(guardSearchDenylist("query")(SearchRepositories(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetFileContents(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(ListCommits(getClient, t))),
+			toolsets.NewServerTool(guardSearchDenylist("q")(guardDenylist(SearchCode(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(GetCommit(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(ListBranches(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(ListTags(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetTag(getClient, t))),
 		).
 		AddWriteTools(
-			toolsets.NewServerTool(guardWrite(CreateOrUpdateFile(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(CreateOrUpdateFile(getClient, t)))),
 			toolsets.NewServerTool(guardCreate(CreateRepository(getClient, t))),
-			toolsets.NewServerTool(guardFork(ForkRepository(getClient, t))),
-			toolsets.NewServerTool(guardWrite(CreateBranch(getClient, t))),
-			toolsets.NewServerTool(guardWrite(PushFiles(getClient, t))),
-			toolsets.NewServerTool(guardWrite(DeleteFile(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(guardFork(ForkRepository(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(CreateBranch(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(PushFiles(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(DeleteFile(getClient, t)))),
 		)
 	issues := toolsets.NewToolset("issues", "GitHub Issues related tools").
 		AddReadTools(
-			toolsets.NewServerTool(GetIssue(getClient, t)),
-			toolsets.NewServerTool(SearchIssues(getClient, t)),
-			toolsets.NewServerTool(ListIssues(getClient, t)),
-			toolsets.NewServerTool(GetIssueComments(getClient, t)),
+			toolsets.NewServerTool(guardDenylist(GetIssue(getClient, t))),
+			toolsets.NewServerTool(guardSearchDenylist("q")(SearchIssues(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(ListIssues(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetIssueComments(getClient, t))),
 		).
 		AddWriteTools(
-			toolsets.NewServerTool(guardWrite(CreateIssue(getClient, t))),
-			toolsets.NewServerTool(guardWrite(AddIssueComment(getClient, t))),
-			toolsets.NewServerTool(guardWrite(UpdateIssue(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(CreateIssue(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(AddIssueComment(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(UpdateIssue(getClient, t)))),
 		)
 	users := toolsets.NewToolset("users", "GitHub User related tools").
 		AddReadTools(
@@ -91,37 +109,37 @@ func InitToolsetsWithConfig(configs []toolsets.ToolsetConfig, readOnly bool, wri
 		)
 	pullRequests := toolsets.NewToolset("pull_requests", "GitHub Pull Request related tools").
 		AddReadTools(
-			toolsets.NewServerTool(GetPullRequest(getClient, t)),
-			toolsets.NewServerTool(ListPullRequests(getClient, t)),
-			toolsets.NewServerTool(GetPullRequestFiles(getClient, t)),
-			toolsets.NewServerTool(GetPullRequestStatus(getClient, t)),
-			toolsets.NewServerTool(GetPullRequestComments(getClient, t)),
-			toolsets.NewServerTool(GetPullRequestReviews(getClient, t)),
-			toolsets.NewServerTool(GetPullRequestDiff(getClient, t)),
+			toolsets.NewServerTool(guardDenylist(GetPullRequest(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(ListPullRequests(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetPullRequestFiles(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetPullRequestStatus(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetPullRequestComments(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetPullRequestReviews(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(GetPullRequestDiff(getClient, t))),
 		).
 		AddWriteTools(
-			toolsets.NewServerTool(guardWrite(MergePullRequest(getClient, t))),
-			toolsets.NewServerTool(guardWrite(UpdatePullRequestBranch(getClient, t))),
-			toolsets.NewServerTool(guardWrite(CreatePullRequest(getClient, t))),
-			toolsets.NewServerTool(guardWrite(UpdatePullRequest(getClient, t))),
-			toolsets.NewServerTool(guardWrite(RequestCopilotReview(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(MergePullRequest(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(UpdatePullRequestBranch(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(CreatePullRequest(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(UpdatePullRequest(getClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(RequestCopilotReview(getClient, t)))),
 
 			// Reviews
-			toolsets.NewServerTool(guardWrite(CreateAndSubmitPullRequestReview(getGQLClient, t))),
-			toolsets.NewServerTool(guardWrite(CreatePendingPullRequestReview(getGQLClient, t))),
-			toolsets.NewServerTool(guardWrite(AddPullRequestReviewCommentToPendingReview(getGQLClient, t))),
-			toolsets.NewServerTool(guardWrite(SubmitPendingPullRequestReview(getGQLClient, t))),
-			toolsets.NewServerTool(guardWrite(DeletePendingPullRequestReview(getGQLClient, t))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(CreateAndSubmitPullRequestReview(getGQLClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(CreatePendingPullRequestReview(getGQLClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(AddPullRequestReviewCommentToPendingReview(getGQLClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(SubmitPendingPullRequestReview(getGQLClient, t)))),
+			toolsets.NewServerTool(guardDenylist(guardWrite(DeletePendingPullRequestReview(getGQLClient, t)))),
 		)
 	codeSecurity := toolsets.NewToolset("code_security", "Code security related tools, such as GitHub Code Scanning").
 		AddReadTools(
-			toolsets.NewServerTool(GetCodeScanningAlert(getClient, t)),
-			toolsets.NewServerTool(ListCodeScanningAlerts(getClient, t)),
+			toolsets.NewServerTool(guardDenylist(GetCodeScanningAlert(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(ListCodeScanningAlerts(getClient, t))),
 		)
 	secretProtection := toolsets.NewToolset("secret_protection", "Secret protection related tools, such as GitHub Secret Scanning").
 		AddReadTools(
-			toolsets.NewServerTool(GetSecretScanningAlert(getClient, t)),
-			toolsets.NewServerTool(ListSecretScanningAlerts(getClient, t)),
+			toolsets.NewServerTool(guardDenylist(GetSecretScanningAlert(getClient, t))),
+			toolsets.NewServerTool(guardDenylist(ListSecretScanningAlerts(getClient, t))),
 		)
 	// Keep experiments alive so the system doesn't error out when it's always enabled
 	experiments := toolsets.NewToolset("experiments", "Experimental features that are not considered stable yet")

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -105,7 +105,7 @@ func InitToolsetsWithConfig(configs []toolsets.ToolsetConfig, readOnly bool, wri
 		)
 	users := toolsets.NewToolset("users", "GitHub User related tools").
 		AddReadTools(
-			toolsets.NewServerTool(SearchUsers(getClient, t)),
+			toolsets.NewServerTool(guardSearchDenylist("q")(SearchUsers(getClient, t))),
 		)
 	pullRequests := toolsets.NewToolset("pull_requests", "GitHub Pull Request related tools").
 		AddReadTools(

--- a/pkg/github/tools_test.go
+++ b/pkg/github/tools_test.go
@@ -73,7 +73,7 @@ func TestInitToolsetsWithConfig(t *testing.T) {
 				return nil, nil
 			}
 
-			tsg, err := InitToolsetsWithConfig(tt.configs, tt.readOnly, false, getClient, getGQLClient, mockTranslator)
+			tsg, err := InitToolsetsWithConfig(tt.configs, tt.readOnly, false, nil, getClient, getGQLClient, mockTranslator)
 
 			if tt.wantErr {
 				if err == nil {
@@ -165,7 +165,7 @@ func TestInitToolsets_BackwardCompatibility(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tsg, err := InitToolsets(tt.passedToolsets, tt.readOnly, false, getClient, getGQLClient, mockTranslator)
+			tsg, err := InitToolsets(tt.passedToolsets, tt.readOnly, false, nil, getClient, getGQLClient, mockTranslator)
 
 			if tt.wantErr {
 				if err == nil {
@@ -255,7 +255,7 @@ func TestToolsetModeFiltering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tsg, err := InitToolsetsWithConfig(tt.configs, false, false, getClient, getGQLClient, mockTranslator)
+			tsg, err := InitToolsetsWithConfig(tt.configs, false, false, nil, getClient, getGQLClient, mockTranslator)
 			if err != nil {
 				t.Fatalf("InitToolsetsWithConfig() error: %v", err)
 			}
@@ -339,7 +339,7 @@ func TestContextToolsetIntegration(t *testing.T) {
 		{Name: "repos", Mode: toolsets.ReadOnly},
 	}
 
-	tsg, err := InitToolsetsWithConfig(configs, false, false, getClient, getGQLClient, mockTranslator)
+	tsg, err := InitToolsetsWithConfig(configs, false, false, nil, getClient, getGQLClient, mockTranslator)
 	if err != nil {
 		t.Fatalf("InitToolsetsWithConfig() error: %v", err)
 	}
@@ -398,13 +398,13 @@ func TestWritePrivateOnlyGuardWiring(t *testing.T) {
 	}
 
 	// Initialize with writePrivateOnly=false
-	tsgOff, err := InitToolsetsWithConfig(configs, false, false, getClient, getGQLClient, mockTranslator)
+	tsgOff, err := InitToolsetsWithConfig(configs, false, false, nil, getClient, getGQLClient, mockTranslator)
 	if err != nil {
 		t.Fatalf("InitToolsetsWithConfig(writePrivateOnly=false) error: %v", err)
 	}
 
 	// Initialize with writePrivateOnly=true
-	tsgOn, err := InitToolsetsWithConfig(configs, false, true, getClient, getGQLClient, mockTranslator)
+	tsgOn, err := InitToolsetsWithConfig(configs, false, true, nil, getClient, getGQLClient, mockTranslator)
 	if err != nil {
 		t.Fatalf("InitToolsetsWithConfig(writePrivateOnly=true) error: %v", err)
 	}
@@ -452,4 +452,66 @@ func TestWritePrivateOnlyGuardWiring(t *testing.T) {
 		}
 	}
 	t.Error("fork_repository tool not found in repos toolset")
+}
+
+func TestRepoDenylistGuardWiring(t *testing.T) {
+	mockTranslator := func(key, fallback string) string { return fallback }
+	getClient := func(_ context.Context, _ string) (*github.Client, error) {
+		return github.NewClient(nil), nil
+	}
+	getGQLClient := func(_ context.Context, _ string) (*githubv4.Client, error) {
+		return nil, nil
+	}
+
+	configs := []toolsets.ToolsetConfig{
+		{Name: "all", Mode: toolsets.ReadWrite},
+	}
+
+	denylist := NewRepoDenylist([]string{"squareup/infosec-minesweeper"})
+
+	// Both should initialize without error
+	tsgOff, err := InitToolsetsWithConfig(configs, false, false, nil, getClient, getGQLClient, mockTranslator)
+	if err != nil {
+		t.Fatalf("InitToolsetsWithConfig(denylist=nil) error: %v", err)
+	}
+	tsgOn, err := InitToolsetsWithConfig(configs, false, false, denylist, getClient, getGQLClient, mockTranslator)
+	if err != nil {
+		t.Fatalf("InitToolsetsWithConfig(denylist=set) error: %v", err)
+	}
+
+	// Both should have the same number of tools (guards don't add/remove tools)
+	for name, tsOff := range tsgOff.Toolsets {
+		tsOn, exists := tsgOn.Toolsets[name]
+		if !exists {
+			t.Errorf("Toolset %s missing when denylist is set", name)
+			continue
+		}
+		if len(tsOff.GetActiveTools()) != len(tsOn.GetActiveTools()) {
+			t.Errorf("Toolset %s: tool count changed with denylist (off=%d, on=%d)",
+				name, len(tsOff.GetActiveTools()), len(tsOn.GetActiveTools()))
+		}
+	}
+
+	// Verify get_file_contents is blocked for denied repo when denylist is set
+	repoToolset := tsgOn.Toolsets["repos"]
+	if repoToolset == nil {
+		t.Fatal("repos toolset not found")
+	}
+	for _, tool := range repoToolset.GetActiveTools() {
+		if tool.Tool.Name == "get_file_contents" {
+			result, err := tool.Handler(context.Background(), createMCPRequest(map[string]interface{}{
+				"owner": "squareup",
+				"repo":  "infosec-minesweeper",
+				"path":  "README.md",
+			}))
+			if err != nil {
+				t.Fatalf("get_file_contents handler returned error: %v", err)
+			}
+			if result == nil || !result.IsError {
+				t.Error("Expected get_file_contents to be blocked for denied repo")
+			}
+			return
+		}
+	}
+	t.Error("get_file_contents tool not found in repos toolset")
 }


### PR DESCRIPTION
BuilderBot/OncallBuddy authenticates via a GitHub App with broad org-level access, meaning users without direct GitHub permissions can inadvertently read regulatory-confidential repositories through MCP tools. This adds a server-side denylist enforced before any GitHub API call is made.

Extends the existing `WritePrivateOnlyGuard` middleware pattern from `write_guard.go`:

- New `RepoDenylistGuard` wraps all tools with `owner`/`repo` params (reads and writes) — covers repos, issues, pull requests, code scanning, secret scanning
- New `SearchDenylistGuard` pre-checks `search_code`, `search_repositories`, and `search_issues` for `repo:`/`org:`/`user:` qualifiers targeting denied repos
- New `DenylistResourceGuard` wraps the five `repo://` resource template handlers
- Configure via `GITHUB_REPO_DENYLIST` as comma-separated `owner/repo` patterns; supports org wildcards (`squareup/*`); parsing matches `GITHUB_TOOLSETS` approach
- Guards compose outermost, so denied repos are rejected before visibility checks or any GitHub API call