### PR TITLE
fix: remove RepoDenylistGuard from search_code tool

### DIFF
--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -77,7 +77,7 @@ func InitToolsetsWithConfig(configs []toolsets.ToolsetConfig, readOnly bool, wri
 			toolsets.NewServerTool(guardSearchDenylist("query")(SearchRepositories(getClient, t))),
 			toolsets.NewServerTool(guardDenylist(GetFileContents(getClient, t))),
 			toolsets.NewServerTool(guardDenylist(ListCommits(getClient, t))),
-			toolsets.NewServerTool(guardSearchDenylist("q")(guardDenylist(SearchCode(getClient, t)))),
+			toolsets.NewServerTool(guardSearchDenylist("q")(SearchCode(getClient, t))),
 			toolsets.NewServerTool(guardDenylist(GetCommit(getClient, t))),
 			toolsets.NewServerTool(guardDenylist(ListBranches(getClient, t))),
 			toolsets.NewServerTool(guardDenylist(ListTags(getClient, t))),


### PR DESCRIPTION
## Problem

`search_code` calls fail with `missing required parameter: owner` even though the tool has no `owner` parameter — it only accepts `q`, `sort`, `order`, and pagination.

## Root Cause

In `tools.go`, `search_code` was wrapped with both `guardDenylist` and `guardSearchDenylist`:

```go
toolsets.NewServerTool(guardSearchDenylist("q")(guardDenylist(SearchCode(getClient, t)))),
```

`RepoDenylistGuard` (invoked by `guardDenylist`) unconditionally calls `requiredParam[string](req, "owner")` and `requiredParam[string](req, "repo")`. Since `search_code` doesn't have these parameters, every invocation fails immediately.

## Fix

Remove the `guardDenylist` wrapper from `search_code`, leaving only `guardSearchDenylist("q")`:

```go
toolsets.NewServerTool(guardSearchDenylist("q")(SearchCode(getClient, t))),
```

`SearchDenylistGuard` already correctly enforces the denylist for search tools by parsing `repo:` and `org:` qualifiers from the query string — the repo-level guard is both unnecessary and incorrect for search tools that don't have explicit `owner`/`repo` parameters.